### PR TITLE
Dev-594 changed report format from xlsx to csv

### DIFF
--- a/app/billing_cycles/sagas.ts
+++ b/app/billing_cycles/sagas.ts
@@ -139,7 +139,7 @@ export function* getBillingCycleReport({ apiUrl, apiPath, token }, { groupId, bi
       throw new Error(data.errors);
     }
     // @ts-ignore
-    saveAs(data, `Report_${year}_${groupName}.xlsx`);
+    saveAs(data, `Report_${year}_${groupName}.csv`);
     yield call(resolve);
   } catch (error) {
     yield call(reject, error);


### PR DESCRIPTION
The report needs to be a csv file so it fits all the Datev rules.